### PR TITLE
Issues with 'saveSettings'

### DIFF
--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -9,7 +9,7 @@ supportedProtocols =
         maxTxBufferSize = 6,
         maxRxBufferSize = 6,
         saveMaxRetries  = 2,
-        saveTimeout     = 150
+        saveTimeout     = 300
     },
     crsf =
     {

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -89,6 +89,10 @@ local function processMspReply(cmd,rx_buf)
     if cmd == Page.write then
         if Page.eepromWrite then
             eepromWrite()
+        else
+            invalidatePages()
+            currentState = pageStatus.display
+            saveTS = 0
         end
         pageRequested = false
         return
@@ -356,7 +360,11 @@ function run_ui(event)
     elseif currentState == pageStatus.saving then
         lcd.drawFilledRectangle(SaveBox.x,SaveBox.y,SaveBox.w,SaveBox.h,backgroundFill)
         lcd.drawRectangle(SaveBox.x,SaveBox.y,SaveBox.w,SaveBox.h,SOLID)
-        lcd.drawText(SaveBox.x+SaveBox.x_offset,SaveBox.y+SaveBox.h_offset,"Saving...",DBLSIZE + BLINK + (globalTextOptions))
+        if saveRetries <= 0 then
+            lcd.drawText(SaveBox.x+SaveBox.x_offset,SaveBox.y+SaveBox.h_offset,"Saving...",DBLSIZE + BLINK + (globalTextOptions))
+        else
+            lcd.drawText(SaveBox.x+SaveBox.x_offset,SaveBox.y+SaveBox.h_offset,"Retrying",DBLSIZE + (globalTextOptions))
+        end
     end
     processMspReply(mspPollReply())
     return 0


### PR DESCRIPTION
I was noticing some issues with 'saveSettings()', so I modified 'run_ui()' to see if save-retries were happening (line 372):

```
        if saveRetries <= 0 then
            lcd.drawText(SaveBox.x+SaveBox.x_offset,SaveBox.y+SaveBox.h_offset,"Saving...",DBLSIZE + BLINK + (globalTextOptions))
        else
            lcd.drawText(SaveBox.x+SaveBox.x_offset,SaveBox.y+SaveBox.h_offset,"Retrying",DBLSIZE + (globalTextOptions))
        end
```
In my test setup I was seeing retries happen on a regular basis, resulting in 'saveSettings()' being called again, which can't be good.  I think the 'saveTimeout' value should be increased, probably to at least 3 seconds.

Also, on the VTX screen it would always timeout and repeat.  Looks like it's because the 'page.eepromWrite' flag is false and the `cmd == uiMsp.eepromWrite` acknowledgement never happens.  I put in a fix for that.  (I know in future the VTX page will probably have "page.eepromWrite=true", but good to have it work right either way.)  I was doing this on the Taranis X7 (smartport), but I'd expect it's the same on the X9.

--ET
